### PR TITLE
GPII-1848: Removes task that used to copy parent 'universal' directory

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -23,13 +23,3 @@
     group: "{{ gpii_framework_groupname }}"
   when: gpii_framework_orca_dir_result.stat.exists == false
   
-# gpii/universal gets installed to the parent node_modules directory relative to gpii/linux
-# https://github.com/GPII/grunt-gpii/blob/master/tasks/gpii.js#L25
-#
-# If a npm path workaround is being used then node_modules/universal in the temporary build
-# directory needs to be copied back to where the application is located.
-# https://github.com/idi-ops/ansible-nodejs/blob/1b849100e68de4d22ef627a709734f67a7314cef/tasks/configure.yml#L23-L29
-- name: Copy universal from the temporary build location to the app installation directory if a Vagrant npm path workaround is being used
-  command: rsync -a "{{ nodejs_app_tmp_build_dir }}/../node_modules" "{{ nodejs_app_install_dir }}/../"
-  when: (is_vagrant) and (nodejs_app_commands)
-


### PR DESCRIPTION
GPII Universal will get installed using npm once https://github.com/GPII/linux/pull/83 is merged so this workaround is no longer required.
