### PR TITLE
GPII-2916 - Enable PackageKit service

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -24,7 +24,8 @@
   when: gpii_framework_orca_dir_result.stat.exists == false
 
 - name: Enable and start PackageKit
-  service:
+  systemd:
     name: packagekit
+    masked: false
     enabled: true
     state: started

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -22,4 +22,9 @@
     owner: "{{ gpii_framework_username }}"
     group: "{{ gpii_framework_groupname }}"
   when: gpii_framework_orca_dir_result.stat.exists == false
-  
+
+- name: Enable and start PackageKit
+  service:
+    name: packagekit
+    enabled: true
+    state: started

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
-- include: install.yml
+- include_tasks: install.yml
   tags:
     - install
   
-- include: configure.yml
+- include_tasks: configure.yml
   tags:
     - configure


### PR DESCRIPTION
The PackageKit service seems to be necessary only by the GPII/linux repository, so instead of keeping it enabled in the Fedora 27 box (which adds a burden to all users since the VM memory would have to be increased), make it a GPII/linux-specific configuration.

GPII/universal tests were failing with PackageKit enabled and 2GB of VM memory (due to out of memory errors). 

GPII/linux are passing with PackageKit and 2GB of memory. It's necessary to monitor the situation and confirm that 2GB continues to be acceptable for GPII/linux.